### PR TITLE
Check rep before welcoming new users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 client.log*
 
 *.pyc
+.idea/

--- a/welcomebot.py
+++ b/welcomebot.py
@@ -94,7 +94,7 @@ def main():
 
 def on_enter(event, client):
     if isinstance(event, ChatExchange.chatexchange.events.UserEntered):
-        if event.user.id == bot.id:
+        if event.user.id == bot.id or event.user.reputation < 20:
             pass
         else:
             if who_to_welcome.check_user(event.user.id, room_id, 'enter'):


### PR DESCRIPTION
If a user's reputation is < 20, you don't need to welcome them as they cannot talk.

**Important**: before running the bot with this commit, run `git submodule update` to be sure your ChatExchange version is the same as the bot's required version.
